### PR TITLE
remove dependency on old external mock

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,6 @@ setup(
     test_suite='tests',
     extras_require={
         'dev': ['check-manifest'],
-        'test': ['coverage', 'mock'],
+        'test': ['coverage'],
     },
 )

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import json
-from unittest import TestCase
-
-import mock
+from unittest import TestCase, mock
 
 from melissa import ApiException
 from melissa.wrapper import MELISSA_URL, Melissa


### PR DESCRIPTION
mock is now part of the Python standard library, available as [unittest.mock](https://docs.python.org/dev/library/unittest.mock.html) in Python 3.3 onwards.

https://github.com/testing-cabal/mock