### PR TITLE
Fix time comparison for cached status

### DIFF
--- a/melissa/__init__.py
+++ b/melissa/__init__.py
@@ -230,7 +230,7 @@ class AsyncMelissa:
             cached
             and self.fetch_timestamp
             and self._time_cache
-            > (datetime.utcnow() - self.fetch_timestamp).total_seconds()
+            > (datetime.now(UTC) - self.fetch_timestamp).total_seconds()
         ):
             return self._latest_status
         url = MELISSA_URL % "provider/fetch"


### PR DESCRIPTION
Update time comparison to use datetime.now(UTC) instead of datetime.utcnow()

I'm getting this error:
```
  File "/usr/local/lib/python3.13/site-packages/melissa/__init__.py", line 233, in async_status
    > (datetime.utcnow() - self.fetch_timestamp).total_seconds()
       ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
TypeError: can't subtract offset-naive and offset-aware datetimes
```